### PR TITLE
Build, train and deploy template on Zeppelin notebook

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "predictionio-toolbox"
 
 organization := "com.github.takezoe"
 
-version := "0.0.2.9-SNAPSHOT"
+version := "0.0.2-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 
@@ -47,7 +47,8 @@ publishMavenStyle := true
 publishTo := {
   val nexus = "https://oss.sonatype.org/"
   if (version.value.trim.endsWith("SNAPSHOT"))
-    Some("snapshots" at nexus + "content/repositories/snapshots")
+    //Some("snapshots" at nexus + "content/repositories/snapshots")
+    Some("zeppelin" at "file:///Users/takezoe/Downloads/zeppelin-0.8.0-bin-all/local-repo")
   else
     Some("releases"  at nexus + "service/local/staging/deploy/maven2")
 }

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "predictionio-toolbox"
 
 organization := "com.github.takezoe"
 
-version := "0.0.1"
+version := "0.0.2.9-SNAPSHOT"
 
 scalaVersion := "2.11.8"
 
@@ -20,6 +20,7 @@ libraryDependencies ++= Seq(
   "org.apache.predictionio"  %% "apache-predictionio-data-jdbc"          % pioVersion,
   "org.apache.predictionio"  %% "apache-predictionio-data-elasticsearch" % pioVersion,
   "org.apache.predictionio"  %% "apache-predictionio-data-hbase"         % pioVersion,
+  "org.eclipse.jgit"         %  "org.eclipse.jgit"                       % "5.0.3.201809091024-r",
   "org.postgresql"           %  "postgresql"                             % "42.1.4",
   "mysql"                    %  "mysql-connector-java"                   % "5.1.46",
   "org.clapper"              %% "grizzled-slf4j"                         % "1.3.2",

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/Common.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/Common.scala
@@ -1,8 +1,15 @@
 package com.github.takezoe.predictionio.toolbox
 
+import java.nio.charset.StandardCharsets
+
 import org.apache.predictionio.data.storage.Storage
+
 import scala.collection.mutable
 import grizzled.slf4j.Logger
+import org.apache.commons.io.IOUtils
+import org.apache.http.client.methods.{HttpGet, HttpPost}
+import org.apache.http.impl.client.HttpClients
+import scala.util.control.Exception._
 
 private[toolbox] object Common {
 
@@ -56,4 +63,31 @@ private[toolbox] object Common {
     }.toMap
   }
 
+//  def curl(method: String, url: String): Int = {
+//    using(HttpClients.createDefault()){ client =>
+//      val response = method.toLowerCase() match {
+//        case "get" =>
+//          val request = new HttpGet(url)
+//          client.execute(request)
+//        case "post" =>
+//          val request = new HttpPost(url)
+//          client.execute(request)
+//      }
+//      val in = response.getEntity.getContent
+//      if(in != null){
+//        println(IOUtils.toString(in, StandardCharsets.UTF_8))
+//      }
+//      response.getStatusLine.getStatusCode
+//    }
+//  }
+
+  def using[A <: { def close(): Unit }, B](resource: A)(f: A => B): B =
+    try f(resource)
+    finally {
+      if (resource != null) {
+        ignoring(classOf[Throwable]) {
+          resource.close()
+        }
+      }
+    }
 }

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOApp.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOApp.scala
@@ -65,7 +65,7 @@ case class PIOApp(
 
   def shutdown(): Unit = {
     if(runningInfo == null){
-      println(s"[${appName}] Service isn't running on the port ${runningInfo.port}.")
+      println(s"[${appName}] Service is not running.")
     } else {
       println(s"[${appName}] Shutdown service...")
       runningInfo.process.destroy()
@@ -75,9 +75,9 @@ case class PIOApp(
 
   def status(): String = {
     if(runningInfo == null){
-      s"[${appName}] Not running"
+      s"[${appName}] Service is not running"
     } else {
-      s"[${appName}] Running on the port ${runningInfo.port}"
+      s"[${appName}] Service is running on the port ${runningInfo.port}"
     }
   }
 

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOApp.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOApp.scala
@@ -25,7 +25,7 @@ case class PIOApp(
   algorithms: String
 ){
   private implicit val formats = Serialization.formats(NoTypeHints)
-  private var runningInfo: RunningInfo = null
+  private[toolbox] var runningInfo: RunningInfo = null
 
   def build(): Int = {
     println(s"[${appName}] Compiling template...")

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOApp.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOApp.scala
@@ -73,11 +73,13 @@ case class PIOApp(
     }
   }
 
-  def status(): String = {
+  def status(): Boolean = {
     if(runningInfo == null){
-      s"[${appName}] Service is not running"
+      println(s"[${appName}] Service is not running")
+      false
     } else {
-      s"[${appName}] Service is running on the port ${runningInfo.port}"
+      println(s"[${appName}] Service is running on the port ${runningInfo.port}")
+      true
     }
   }
 

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOApp.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOApp.scala
@@ -1,0 +1,76 @@
+package com.github.takezoe.predictionio.toolbox
+
+import java.io.File
+
+import org.apache.commons.io.FileUtils
+import org.json4s.NoTypeHints
+import org.json4s._
+import org.json4s.native.Serialization
+import org.json4s.native.JsonMethods.parse
+import scala.collection.JavaConverters._
+
+case class Algorithm(name: String, params: Map[String, Any])
+
+case class PIOApp(
+  pioHome: String,
+  appName: String,
+  url: String,
+  dir: File,
+  algorithms: String
+){
+  private implicit val formats = Serialization.formats(NoTypeHints)
+
+  def build(): Int = {
+    println("Compiling application...")
+    executeCommand(Seq(s"$pioHome/bin/pio", "build"))
+  }
+
+  def open(): Unit = {
+    executeCommand(Seq("open", dir.getAbsolutePath))
+  }
+
+  def train(algorithms: String = ""): Int = {
+    if(algorithms.nonEmpty){
+      // Update configuration
+      val configJson = JObject(JField("algorithms", parse(algorithms)))
+
+      val file = new File(dir, "engine.json")
+      val json = parse(FileUtils.readFileToString(file)).merge(configJson)
+
+      val jsonString = Serialization.write(json)
+      FileUtils.write(file, jsonString)
+    }
+
+    println("Training model...")
+    executeCommand(Seq(s"$pioHome/bin/pio", "train"))
+  }
+
+  def deploy(): Int = {
+    println("Deploying service...")
+    executeCommand(Seq(s"$pioHome/bin/pio", "deploy"))
+  }
+
+  private def executeCommand(command: Seq[String]): Int = {
+    val builder = new ProcessBuilder(command: _*).directory(dir)
+
+    // Remove SPARK keys
+    val keys = builder.environment().asScala.collect { case (key, value) if key.startsWith("SPARK") => key }
+    keys.foreach(builder.environment().remove)
+    val process = builder.start()
+
+    val logger1 = new ProcessLogger(process.getInputStream)
+    val logger2 = new ProcessLogger(process.getErrorStream)
+    logger1.start()
+    logger2.start()
+
+    process.waitFor()
+
+    while(!logger1.completed || !logger2.completed){
+      Thread.sleep(100)
+    }
+
+    process.exitValue()
+  }
+
+  // TODO How to shutdown deployed API?
+}

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
@@ -75,10 +75,10 @@ case class PIOToolbox(pioHome: String) {
 
     val algorithms = Serialization.write((json \ "algorithms"))
 
-    PIOApp(pioHome, appName, templateUrl, dir, algorithms)
+    PIOApp(this, appName, templateUrl, dir, algorithms)
   }
 
-  def find(
+  def findEventRDD(
     appName: String,
     channelName: Option[String] = None,
     startTime: Option[DateTime] = None,
@@ -102,7 +102,7 @@ case class PIOToolbox(pioHome: String) {
     )(sc)
   }
 
-  def write(
+  def writeEventRDD(
     events: RDD[Event],
     appName: String,
     channelName: Option[String] = None
@@ -111,7 +111,7 @@ case class PIOToolbox(pioHome: String) {
     Storage.getPEvents().write(events, appId, channelId)(sc)
   }
 
-  def insert(
+  def insertEvent(
     event: Event,
     appName: String,
     channelName: Option[String] = None
@@ -120,7 +120,7 @@ case class PIOToolbox(pioHome: String) {
     Storage.getLEvents().futureInsert(event, appId, channelId)
   }
 
-  def insertBatch(
+  def insertEventBatch(
     events: Seq[Event],
     appName: String,
     channelName: Option[String] = None

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
@@ -42,11 +42,11 @@ case class PIOToolbox(pioHome: String) {
     override def filter(filterExpression: ((String, String)) => Boolean): Map[String, String] = config.filter(filterExpression)
   })
 
-  def apps(): String = {
+  def apps(): Unit = {
     val apps = storage.Storage.getMetaDataApps()
     val keys = storage.Storage.getMetaDataAccessKeys()
 
-    "%html\n" +
+    val html = "%html\n" +
       "<table border=\"1\">" +
       "<tr><th>ID</th><th>Name</th><th>Service Status</th><th>Access Key</th><th>Directory</th></tr>" +
       (apps.getAll().map { app =>
@@ -70,6 +70,10 @@ case class PIOToolbox(pioHome: String) {
         }.mkString
       }.mkString) +
       "</table>"
+
+    println(html)
+
+    ()
   }
 
   def deleteApp(appName: String): Unit = {
@@ -117,9 +121,19 @@ case class PIOToolbox(pioHome: String) {
         }
 
         val json = parse(FileUtils.readFileToString(file))
-        val algorithms = Serialization.write((json \ "algorithms"))
+        val algorithmsParams = Serialization.write((json \ "algorithms"))
+        val engineId = (json \ "engineFactory").asInstanceOf[JString].values
+        val variantId = (json \ "id").asInstanceOf[JString].values
 
-        PIOApp(this, appName, templateUrl, dir, algorithms)
+        PIOApp(
+          toolbox          = this,
+          appName          = appName,
+          url              = templateUrl,
+          dir              = dir,
+          engineId         = engineId,
+          variantId        = variantId,
+          algorithmsParams = algorithmsParams
+        )
 
       case None =>
         val appId = apps.insert(App(0, appName, None))
@@ -143,9 +157,19 @@ case class PIOToolbox(pioHome: String) {
 
         // Extract algorithm parameters from engine.json
         val json = parse(FileUtils.readFileToString(file))
-        val algorithms = Serialization.write((json \ "algorithms"))
+        val algorithmsParams = Serialization.write((json \ "algorithms"))
+        val engineId = (json \ "engineFactory").asInstanceOf[JString].values
+        val variantId = (json \ "id").asInstanceOf[JString].values
 
-        PIOApp(this, appName, templateUrl, dir, algorithms)
+        PIOApp(
+          toolbox          = this,
+          appName          = appName,
+          url              = templateUrl,
+          dir              = dir,
+          engineId         = engineId,
+          variantId        = variantId,
+          algorithmsParams = algorithmsParams
+        )
     }
 
     managedApps += app

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
@@ -19,6 +19,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 case class PIOToolbox(pioHome: String) {
 
+  private val templateDir = new File(s"$pioHome/templates")
   private val file = new java.io.File(s"$pioHome/conf/pio-env.sh")
   private implicit val formats = Serialization.formats(NoTypeHints)
 
@@ -44,46 +45,87 @@ case class PIOToolbox(pioHome: String) {
 
     "%html\n" +
       "<table border=\"1\">" +
-      "<tr><th>ID</th><th>Name</th><th>Description</th><th>Access Key</th><th>Allowed Event(s)</th></tr>" + (apps.getAll().map { app =>
-        keys.getByAppid(app.id).map { key =>
-          "<tr><td>" + app.id + "</td><td>" + app.name + "</td><td>" + app.description + "</td><td>" + key.key + "</td><td>" +
-            (if(key.events.isEmpty) "(all)" else key.events.mkString(", ")) + "</td></tr>"
+      "<tr><th>ID</th><th>Name</th><th>Description</th><th>Access Key</th><th>Allowed Event(s)</th><th>Directory</th></tr>" +
+      (apps.getAll().map { app =>
+        val appKeys = keys.getByAppid(app.id)
+        (if(appKeys.isEmpty) Seq(AccessKey("None", app.id, Seq("None"))) else appKeys).map { key =>
+          "<tr>" +
+            "<td>" + app.id + "</td>" +
+            "<td>" + app.name + "</td>" +
+            "<td>" + app.description + "</td>" +
+            "<td>" + key.key + "</td>" +
+            "<td>" + (if(key.events.isEmpty) "(all)" else key.events.mkString(", ")) + "</td>" +
+            "<td>" + {
+              val dir = new File(s"$templateDir/${app.name}")
+              if(dir.exists()) dir.getAbsolutePath else "None"
+            } + "</td>" +
+            "</tr>"
         }.mkString
       }.mkString) +
       "</table>"
   }
 
+  def deleteApp(appName: String): Unit = {
+    val apps = storage.Storage.getMetaDataApps()
+    apps.getByName(appName).foreach { x =>
+      apps.delete(x.id)
+    }
+
+    val dir = new File(templateDir, appName)
+    if(dir.exists()){
+      FileUtils.deleteQuietly(dir)
+    }
+  }
+
   def createApp(appName: String, templateUrl: String): PIOApp = {
     val apps = storage.Storage.getMetaDataApps()
+    val keys = storage.Storage.getMetaDataAccessKeys()
+
     apps.getByName(appName) match {
       case Some(_) =>
-        // TODO Use the existing template directory instead of cloning template
-        println(s"${appName} already exists.")
+        val dir = new File(templateDir, appName)
+        if(!dir.exists()){
+          throw new IllegalStateException(s"[${appName}] Application is registered but template does not exist! " +
+            s"Try to run `toolbox.deleteApp(appName)` before creating the application.")
+        }
+
+        // Check template can be used out-of-the-box
+        val file = new File(dir, "engine.json")
+        if(!file.exists()){
+          throw new IllegalStateException(s"[${appName}] engine.json does not exist!")
+        }
+
+        val json = parse(FileUtils.readFileToString(file))
+        val algorithms = Serialization.write((json \ "algorithms"))
+
+        PIOApp(this, appName, templateUrl, dir, algorithms)
+
       case None =>
-        println(s"Create application: ${appName}")
-        apps.insert(App(0, appName, None))
+        val appId = apps.insert(App(0, appName, None))
+        keys.insert(AccessKey("", appId.get, Nil))
+
+        val dir = new File(templateDir, appName)
+
+        // Clone template
+        println(s"[${appName}] Cloning template...")
+        Git.cloneRepository().setURI(templateUrl).setDirectory(dir).call()
+
+        // Check template can be used out-of-the-box
+        val file = new File(dir, "engine.json")
+        if(!file.exists()){
+          throw new IllegalStateException(s"[${appName}] engine.json does not exist!")
+        }
+
+        // Update appName
+        val json = parse(FileUtils.readFileToString(file))
+          .merge(JObject(JField("datasource", JObject(JField("params", JObject(JField("appName", JString(appName))))))))
+        val jsonString = Serialization.write(json)
+        FileUtils.write(file, jsonString)
+
+        val algorithms = Serialization.write((json \ "algorithms"))
+
+        PIOApp(this, appName, templateUrl, dir, algorithms)
     }
-
-    // Clone template
-    println(s"[${appName}] Cloning template...")
-    val dir = Files.createTempDirectory(appName).toFile
-    Git.cloneRepository().setURI(templateUrl).setDirectory(dir).call()
-
-    // Check template can be used out-of-the-box
-    val file = new File(dir, "engine.json")
-    if(!file.exists()){
-      throw new IllegalStateException("This template is not able to be used out-of-the-box!")
-    }
-
-    // Update appName
-    val json = parse(FileUtils.readFileToString(file))
-      .merge(JObject(JField("datasource", JObject(JField("params", JObject(JField("appName", JString(appName))))))))
-    val jsonString = Serialization.write(json)
-    FileUtils.write(file, jsonString)
-
-    val algorithms = Serialization.write((json \ "algorithms"))
-
-    PIOApp(this, appName, templateUrl, dir, algorithms)
   }
 
   def findEventRDD(

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
@@ -38,13 +38,19 @@ case class PIOToolbox(pioHome: String) {
     override def filter(filterExpression: ((String, String)) => Boolean): Map[String, String] = config.filter(filterExpression)
   })
 
-  def apps(): Seq[Map[String, Any]] = {
+  def apps(): String = {
     val apps = storage.Storage.getMetaDataApps()
     val keys = storage.Storage.getMetaDataAccessKeys()
 
-    apps.getAll().map { app =>
-      Map("id" -> app.id, "name" -> app.name, "description" -> app.description, "accessKey" -> keys.getByAppid(app.id))
-    }
+    "%html\n" +
+      "<table border=\"1\">" +
+      "<tr><th>ID</th><th>Name</th><th>Description</th><th>Access Key</th><th>Allowed Event(s)</th></tr>" + (apps.getAll().map { app =>
+        keys.getByAppid(app.id).map { key =>
+          "<tr><td>" + app.id + "</td><td>" + app.name + "</td><td>" + app.description + "</td><td>" + key.key + "</td><td>" +
+            (if(key.events.isEmpty) "(all)" else key.events.mkString(", ")) + "</td></tr>"
+        }.mkString
+      }.mkString) +
+      "</table>"
   }
 
   def createApp(appName: String, templateUrl: String): PIOApp = {

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
@@ -48,7 +48,7 @@ case class PIOToolbox(pioHome: String) {
 
     "%html\n" +
       "<table border=\"1\">" +
-      "<tr><th>ID</th><th>Name</th><th>Status</th><th>Access Key</th><th>Directory</th></tr>" +
+      "<tr><th>ID</th><th>Name</th><th>Service Status</th><th>Access Key</th><th>Directory</th></tr>" +
       (apps.getAll().map { app =>
         val appKeys = keys.getByAppid(app.id)
         (if(appKeys.isEmpty) Seq(AccessKey("None", app.id, Seq("None"))) else appKeys).map { key =>

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
@@ -57,13 +57,15 @@ case class PIOToolbox(pioHome: String) {
     val apps = storage.Storage.getMetaDataApps()
     apps.getByName(appName) match {
       case Some(_) =>
-        println(s"Application: ${appName} already exists.")
+        // TODO Use the existing template directory instead of cloning template
+        println(s"${appName} already exists.")
       case None =>
         println(s"Create application: ${appName}")
         apps.insert(App(0, appName, None))
     }
 
     // Clone template
+    println(s"[${appName}] Cloning template...")
     val dir = Files.createTempDirectory(appName).toFile
     Git.cloneRepository().setURI(templateUrl).setDirectory(dir).call()
 

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
@@ -1,16 +1,26 @@
 package com.github.takezoe.predictionio.toolbox
 
+import java.io.File
+import java.nio.file.Files
+
 import org.apache.commons.io.FileUtils
+import org.apache.predictionio.data.storage
 import org.apache.predictionio.data.storage._
 import org.apache.predictionio.data.store.PEventStore
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
+import org.eclipse.jgit.api.Git
 import org.joda.time.DateTime
+import org.json4s._
+import org.json4s.native.JsonMethods._
+import org.json4s.native.Serialization
+
 import scala.concurrent.ExecutionContext.Implicits.global
 
 case class PIOToolbox(pioHome: String) {
 
   private val file = new java.io.File(s"$pioHome/conf/pio-env.sh")
+  private implicit val formats = Serialization.formats(NoTypeHints)
 
   val config: Map[String, String] = Common.processEnvVars(pioHome,
     FileUtils.readFileToString(file).split("\n").map { line =>
@@ -27,6 +37,46 @@ case class PIOToolbox(pioHome: String) {
     override def getByKey(key: String): String = config.get(key).orNull
     override def filter(filterExpression: ((String, String)) => Boolean): Map[String, String] = config.filter(filterExpression)
   })
+
+  def apps(): Seq[Map[String, Any]] = {
+    val apps = storage.Storage.getMetaDataApps()
+    val keys = storage.Storage.getMetaDataAccessKeys()
+
+    apps.getAll().map { app =>
+      Map("id" -> app.id, "name" -> app.name, "description" -> app.description, "accessKey" -> keys.getByAppid(app.id))
+    }
+  }
+
+  def createApp(appName: String, templateUrl: String): PIOApp = {
+    val apps = storage.Storage.getMetaDataApps()
+    apps.getByName(appName) match {
+      case Some(_) =>
+        println(s"Application: ${appName} already exists.")
+      case None =>
+        println(s"Create application: ${appName}")
+        apps.insert(App(0, appName, None))
+    }
+
+    // Clone template
+    val dir = Files.createTempDirectory(appName).toFile
+    Git.cloneRepository().setURI(templateUrl).setDirectory(dir).call()
+
+    // Check template can be used out-of-the-box
+    val file = new File(dir, "engine.json")
+    if(!file.exists()){
+      throw new IllegalStateException("This template isn't able to be used out-of-the-box!")
+    }
+
+    // Update appName
+    val json = parse(FileUtils.readFileToString(file))
+      .merge(JObject(JField("datasource", JObject(JField("params", JObject(JField("appName", JString(appName))))))))
+    val jsonString = Serialization.write(json)
+    FileUtils.write(file, jsonString)
+
+    val algorithms = Serialization.write((json \ "algorithms"))
+
+    PIOApp(pioHome, appName, templateUrl, dir, algorithms)
+  }
 
   def find(
     appName: String,

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/PIOToolbox.scala
@@ -72,7 +72,7 @@ case class PIOToolbox(pioHome: String) {
     // Check template can be used out-of-the-box
     val file = new File(dir, "engine.json")
     if(!file.exists()){
-      throw new IllegalStateException("This template isn't able to be used out-of-the-box!")
+      throw new IllegalStateException("This template is not able to be used out-of-the-box!")
     }
 
     // Update appName

--- a/src/main/scala/com/github/takezoe/predictionio/toolbox/ProcessLogger.scala
+++ b/src/main/scala/com/github/takezoe/predictionio/toolbox/ProcessLogger.scala
@@ -1,0 +1,23 @@
+package com.github.takezoe.predictionio.toolbox
+
+import java.io.{BufferedReader, InputStream, InputStreamReader}
+import java.nio.charset.StandardCharsets
+
+class ProcessLogger(in: InputStream) extends Thread {
+
+  var completed = false
+
+  override def run(): Unit = {
+    val reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))
+    while(!completed){
+      val line = reader.readLine()
+      if(line == null){
+        completed = true
+      } else {
+        //println(line)
+        Thread.sleep(100)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This makes possible to clone, build, train and deploy templates on Zeppelin. Also it make possible to manage the status of templates and deployed services.

## Overview

![predictionio-zeppelin](https://user-images.githubusercontent.com/1094760/45586476-f2ee3180-b932-11e8-88e9-19a8474693f4.png)

## Usage

```scala
import com.github.takezoe.predictionio.toolbox._

val toolbox = PIOToolbox("/Users/takezoe/PredictionIO-0.13.0")
val app = toolbox.createApp("MyApp1", "https://github.com/apache/predictionio-template-recommender.git")
```

Following methods are available on the application:

```scala
app.build()
app.train()
app.deploy()
app.shutdown()
```

If you need to modify training parameter, you can give them as below:

```scala
app.train("""[{"name":"als","params":{"rank":10,"numIterations":5,"lambda":0.01,"seed":3}}]""")
```

Also you can deploy with a specified port and an engine instance as below:

```scala
app.deploy(port = 8081, engineInstanceId="0ead6714-7072-45e3-8c55-6582f001d8b4")
```

Available engine instances can be shown by `app.engines()`:

![2018-09-17 22 06 10](https://user-images.githubusercontent.com/1094760/45624741-2a411780-bac6-11e8-9192-30552c1746a1.png)

## TODO

- Multiple engines deployment from one template
- It's nice if we can modify something in template on notebook
- Specify engineInstanceId when deploying (It also requires a way to confirm engineInstanceId)
- Service status should be managed PredictionIO side
